### PR TITLE
Patch for CS:GO compatibility

### DIFF
--- a/STARK/CommandReader.cs
+++ b/STARK/CommandReader.cs
@@ -35,7 +35,7 @@ namespace STARK {
 
         public CommandReader(ref QueuedSpeechSynthesizer qss, ref AudioPlaybackEngine ape, ref AudioFileManager afm, SourceGame selectedGame) {
             this.selectedGame = selectedGame;
-            this.logFile = PathManager.steamApps + MainWindow.gameDir + @"\!tts-axynos.txt";
+            this.logFile = PathManager.steamApps + MainWindow.gameDir + @"\!tts-axynos.log";
             this.qss = qss;
             this.ape = ape;
             this.afm = afm;

--- a/STARK/ConsoleUI.cs
+++ b/STARK/ConsoleUI.cs
@@ -82,7 +82,7 @@ namespace STARK {
                 "alias s_stop \"exec s_stop\"",
                 "alias s_tracklist \"exec s_tracklist\"",
                 "alias s_help \"exec s_help\"",
-                "con_logfile !tts-axynos.txt",
+                "con_logfile !tts-axynos.log",
                 "exec s_help"
             });
 


### PR DESCRIPTION
As referenced in issue [#1](https://github.com/GrimReaperFloof/STARK/issues/1#issuecomment-569784270), CS:GO developers silently updated the requirement for con_logfile to have a .log file extension.

This patch implements the change in the initialization step (usage of the exec command) and in the command input handler (reading from the correct file).